### PR TITLE
Multiply sharetime.total_seconds() for millis

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -542,7 +542,7 @@ def handle(c):
                 except:
                     break
                 sharetime = resultreceived - jobsent # Time from start of hash computing to finding the result
-                sharetime = int(sharetime.total_seconds() / 1000) # Get total ms
+                sharetime = int(sharetime.total_seconds() * 1000) # Get total ms
                 reward = int(int(sharetime) **2) / 750000000 # Calculate reward dependent on share submission time
                 try: # If client submitted hashrate, use it
                     hashrate = float(response[1])


### PR DESCRIPTION
In commit 89b0e27e9c22079d28e80035e1ff892264212a39, the `*` operator on the line `sharetime = int(sharetime.total_seconds() * 1000)` that I contributed recently got changed to a `/`. This will not work because the `.total_seconds()` method returns in seconds, and this needs to be multiplied by 1000 to get milliseconds.

This is a quick PR to fix that.