### PR TITLE
Fix hashrate calculation

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -607,7 +607,7 @@ def handle(c):
                     hashrateEstimated = False
                 except: # If not, estimate it ourselves
                     try:
-                        hashrate = int(rand) / int(sharetime) * 2000000 / int(diff) # This formula gives a rough estimation of the hashrate
+                        hashrate = int(rand / (sharetime / 1000)) # This formula gives a rough estimation of the hashrate
                     except ZeroDivisionError:
                         hashrate = 1000
                     hashrateEstimated = True


### PR DESCRIPTION
Assuming a search starting from zero and progressing up, the correct expression for hashrate is `rand / (sharetime / 1000)` where `sharetime` is in milliseconds. This is literally the number of hashes calculated over time.

The current expression can be rearranged into `(range / (sharetime / 1000)) * (2000 / diff)`, meaning it is only equal to the above when the difficulty is at 2000. If the actual difficulty is larger, that makes the estimated hashrate smaller than expected.