### PR TITLE
Fixed simple mathematical error

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -952,17 +952,19 @@ def handle(c, ip):
                         p = 2 - sharetime / expected_sharetime
 
                         # Check if multiplier is higher than 10%
-                        if p >= 1.1:
+                        if p > 1.1:
                             # Calculate new difficulty
                             new_diff = int(diff * p)
                         else:
                             new_diff = int(diff)
-                            
-                        if new_diff <= 0:
+                        
+                        # Checks whether sharetime was higher than expected 
+                        # (p = 1 equals to sharetime = expected_sharetime)
+                        if p < 1:
                             # If sharetime was longer than expected,
                             # Lower the difficulty
                             # Calculate the multiplier again for lowering
-                            new_diff = int(diff / p) * -1
+                            new_diff = int(diff * p) * -1
                             diff = int(new_diff)
                         else:
                             # If sharetime was shorter than expected,


### PR DESCRIPTION
I replaced " if new_diff <= 0" with "p < 1" due to the first condition being nearly impossible to reach, unless the sharetime is 2.x times longer than expected. Thus I as well replaced the following "new_diff = int(diff / p) * -1" with "new_diff = int(diff * p) * -1" due to p being lower than 1 and thus it would've actually increased the diff with dividing.

(e.g. 30000 / 0.5 = 60k, but 30k * 0.5 = 15k)
I obviously documented this change as well above the actual if statement. I recommend looking at this again, 'cause I rarely code with python and may have fucked up the indents at line 960 - 972