### PR TITLE
Add pinMode to setup

### DIFF
--- a/ESP32_Code/ESP32_Code.ino
+++ b/ESP32_Code/ESP32_Code.ino
@@ -273,6 +273,9 @@ void setup() {
   }
   Serial.println("\nConnected to WiFi!");
   Serial.println("Local IP address: " + WiFi.localIP().toString());
+
+  pinMode(LED_BUILTIN,OUTPUT);
+  
   xTaskCreatePinnedToCore(Task1code, "Task1", 10000, NULL, 1, &Task1, 0); //create a task with priority 1 and executed on core 0
   delay(250);
   xTaskCreatePinnedToCore(Task2code, "Task2", 10000, NULL, 2, &Task2, 1); //create a task with priority 2 and executed on core 1


### PR DESCRIPTION
## Problem
The builtin LED doesn't blink on ESP32 devices.

## Verdict
Even though the code is there to make it blink, the `pinMode` is not set for the `LED_BUILTIN` pin.

## Resolution
Added `pinMode(LED_BUILTIN,OUTPUT);` to the `setup()` function.