### PR TITLE
Update AVR_Miner.py

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -797,7 +797,7 @@ def AVRMine(com):
                 try:
                     # Send job request
                     debugOutput("Requested job from the server")
-                    socConn.send(
+                    socConn.sendall(
                         bytes(
                             "JOB,"
                             + str(username)
@@ -943,7 +943,7 @@ def AVRMine(com):
 
                 try:
                     # Send result to the server
-                    socConn.send(
+                    socConn.sendall(
                         bytes(
                             str(ducos1result)
                             + ","


### PR DESCRIPTION
Changing the socket .send() to .sendall() in lines #800 and #946. I have found that sometimes, depending on the network speed or latency, the message from the server can take some time to arrive or can arrive fragmented, this can cause some corruption on the code that could be dragged for the next jobs and never recover from it. sendall() seems to be more stable. On my side is working good but it would be better if someone else can test it.