### PR TITLE
Add helpers

### DIFF
--- a/linux-device-paths
+++ b/linux-device-paths
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
+    (
+        syspath="${sysdevpath%/dev}"
+        devname="$(udevadm info -q name -p $syspath)"
+        [[ "$devname" == "bus/"* ]] && exit
+        eval "$(udevadm info -q property --export -p $syspath)"
+        [[ -z "$ID_SERIAL" ]] && exit
+        echo "/dev/$devname - $ID_SERIAL"
+    )
+done

--- a/upload-sketch.py
+++ b/upload-sketch.py
@@ -1,0 +1,40 @@
+import sys
+import subprocess
+from configparser import ConfigParser
+
+MINER_VER = '2.45'  # Version number
+RESOURCES_DIR = 'AVRMiner_' + str(MINER_VER) + '_resources'
+
+config = ConfigParser()
+
+print('Checking for arduino-cli…')
+try:
+    subprocess.call(['arduino-cli'])
+except Exception as e:
+    print('arduino-cli is not installed. Please follow this tutorial https://siytek.com/arduino-cli-raspberry-pi/ and then try the script again.')
+    sys.exit()
+
+print('arduino-cli is installed…')
+
+try:
+    print('Fetching config…')
+    config.read(RESOURCES_DIR + '/Miner_config.cfg')
+    avrport = config['arduminer']['avrport']
+except Exception as e:
+    print(f'Cannot get config: {e}')
+    sys.exit()
+
+try:
+    subprocess.call('arduino-cli compile --fqbn arduino:avr:uno Arduino_Code/Arduino_Code.ino'.split(' '))
+except Exception as e:
+    print(f'Cannot compile: {e}')
+    sys.exit()
+
+ports = avrport.split(',')
+for port in ports:
+    print(f'Uploading to {port}')
+    try:
+        subprocess.call(f'arduino-cli upload -p {port} --fqbn arduino:avr:uno Arduino_Code/Arduino_Code.ino'.split(' '))
+    except Exception as e:
+        print(f'Error uploading to {port}: {e}')
+        sys.exit()


### PR DESCRIPTION
## Backstory
This PR adds 2 files which some users might find useful.

`linux-device-paths` - returns a list of device paths and the device ID that's using that path. Helpful as some USB devices don't use `/dev/ttyUSB*`

`upload-sketch.py` - a script to upload the AVR sketch to AVR devices. Requires `arduino-cli` to be installed and setup, but this _could_ help temporarily fix the `too many errors` issue. Not sure how to factor that into the AVR Miner though.