### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Server source code, documentation for API calls and official libraries for devel
 | Arduino Pro Mini, Uno, Nano etc.<br>(Atmega 328p/pb/16u2) | 170 H/s                           | 1                 | 0.2 W          | 7-8                 |
 | Teensy 4.1                                                | 12.8 kH/s                         | 1                 | -              | -                   |
 | NodeMCU, Wemos D1 etc.<br>(ESP8266)                       | 9.3 kH/s                          | 1                 | 0.6 W          | 6-8                 |
-| ESP32                                                     | 27 kH/s                           | 2                 | 1.25 W         | -                   |
+| ESP32                                                     | 23 kH/s                           | 2                 | 1 W            | 8-9                 |
 | Raspberry Pi Zero                                         | 17 kH/s                           | 1                 | 0.7 W          | -                   |
 | Raspberry Pi 3                                            | 440 kH/s                          | 4                 | 5.1 W          | -                   |
 | Raspberry Pi 4                                            | 1.3 MH/s                          | 4                 | 6.4 W          | -                   |


### PR DESCRIPTION
I've run some tests with the ESP32 as close as possible to my router and with a USB current monitor. I've found that the the hashrate goes between 21 and 26 KH/s it could get rarely to 27 but it is not common and mostly it will stay in 23, the daily profit goes between 8 and above 9 but never 10 and the current goes between 90mA to 160mA so in rare cases it could go up to 200mA. So with this results I think it's better to say that the ESP32 has an average hashrate of 23 KH/s, daily profit of 8-9 DUCO and average power 1 W (it's really more like peak power but in this case the worst scenario is better).