### PR TITLE
Update hash.c

### DIFF
--- a/Arduino_Code/sha1/hash.c
+++ b/Arduino_Code/sha1/hash.c
@@ -159,7 +159,7 @@ uint8_t * sha1_hasher_gethash(sha1_hasher_t hasher)
 	uint8_t i;
 
 	// switch byte order.
-	for(i = 0; i < 8; i++)
+	for(i = 0; i < (SHA1_HASH_LEN / 4); i++)
 	{
 		uint32_t a, b;
 		a = hasher->state.words[i];


### PR DESCRIPTION
Small change. This loop doesn't get to 8 because the maximum size of state.words is (SHA1_HASH_LEN / 4) and SHA1_HASH_LEN is 20. It's better to use the constant name instead of a fixed value. This has been pointed out by the compiler when you put the higher warning level.