### PR TITLE
ssize_ definition

### DIFF
--- a/Arduino_Code/sha1/sha1.h
+++ b/Arduino_Code/sha1/sha1.h
@@ -23,7 +23,7 @@
 #include <stddef.h>
 //#include <unistd.h>
 
-#ifdef __AVR__
+#ifndef ssize_t
 #define ssize_t long int
 #endif
 


### PR DESCRIPTION
Small change. Defining ssize_ type (which is not a standard c data type) for all the boards that don't have it defined, not just AVR boards.