### PR TITLE
Use of PROGMEM and make the code more generic

### DIFF
--- a/Arduino_Code/sha1/constants.c
+++ b/Arduino_Code/sha1/constants.c
@@ -16,21 +16,13 @@
 
 #include "constants.h"
 
-#ifndef __AVR__
-const uint32_t sha1_init_state[SHA1_HASH_LEN / 4] =
-#else
 const uint32_t sha1_init_state[SHA1_HASH_LEN / 4] PROGMEM =
-#endif
 {
 	0x67452301, 0xefcdab89, 0x98badcfe,
 	0x10325476, 0xc3d2e1f0
 };
 
-#ifndef __AVR__
-const uint32_t sha1_constants[4] = 
-#else
 const uint32_t sha1_constants[4] PROGMEM =
-#endif
 {
 	0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6
 };

--- a/Arduino_Code/sha1/constants.h
+++ b/Arduino_Code/sha1/constants.h
@@ -23,21 +23,11 @@
 #define SHA1_BLOCK_LEN 64
 #define SHA1_HASH_LEN 20
 
-#ifdef __AVR__
-#include <avr/pgmspace.h>
-#endif
+#include "Arduino.h"
 
-#ifndef __AVR__
-extern const uint32_t sha1_init_state[SHA1_HASH_LEN / 4];
-#else
 extern const uint32_t sha1_init_state[SHA1_HASH_LEN / 4] PROGMEM;
-#endif
 
-#ifndef __AVR__
-extern const uint32_t sha1_constants[4];
-#else
 extern const uint32_t sha1_constants[4] PROGMEM;
-#endif
 
 
 // From RFC3174 (http://www.faqs.org/rfcs/rfc3174.html) 
@@ -56,11 +46,7 @@ extern const uint32_t sha1_constants[4] PROGMEM;
 // 
 // This can be achieved using an integer division by 20 and only 4 constants.
 
-#ifdef __AVR__
 #define sha1_k(i) pgm_read_dword(sha1_constants + (i / 20))
-#else
-#define sha1_k(i) sha1_constants[i / 20]
-#endif
 
 
 #ifdef SHA1_ENABLE_HMAC

--- a/Arduino_Code/sha1/types.c
+++ b/Arduino_Code/sha1/types.c
@@ -32,15 +32,11 @@ sha1_hasher_t sha1_hasher_new(void)
 
 void sha1_hasher_init(sha1_hasher_t hasher)
 {
-#ifdef __AVR__
 	uint8_t i;
 	for(i = 0; i < SHA1_HASH_LEN / 4; i++)
 	{
 		hasher->state.words[i] = pgm_read_dword(sha1_init_state + i);
 	}
-#else
-	memcpy(hasher->state.words, sha1_init_state, SHA1_HASH_LEN);
-#endif
 	hasher->block_offset = 0;
 	hasher->total_bytes = 0;
 	hasher->_lock = 0;


### PR DESCRIPTION
While I was working with the megaAVR architectures I found out that there were some portions of code that depend on the AVR architecture. Since the megaAVR is not strictly AVR architecture I had to change that but while I was looking at it and doing some research I found out that the use of PROGMEM and all the flash or program memory instructions are not exclusive to the AVR architectures, all the other architectures do what's necessary to handle them:

https://www.arduino.cc/reference/en/language/variables/utilities/progmem/
https://arduino.stackexchange.com/questions/65273/how-to-use-progmem-in-a-h-cpp-file-instead-of-a-ino-file

The use of #include "Arduino.h" is enough for this and is more generic. I have tested the code with the Teensy 4.1, a SAMD21 board, the Leonardo board and the ESP32 (as serial miner). I have checked and it also compile on the Raspberry Pi Pico, the megaAVR boards and STM32 but haven't tested them yet since I don't have any.