### PR TITLE
Use of typedef to choose the size of difficulty

### DIFF
--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -55,7 +55,7 @@ void setup() {
 }
 
 // DUCO-S1A hasher
-uintDiff ducos1a(String lastblockhash, String newblockhash, uint16_t difficulty)
+uintDiff ducos1a(String lastblockhash, String newblockhash, uintDiff difficulty)
 {
   // DUCO-S1 algorithm implementation for AVR boards (DUCO-S1A)
   newblockhash.toUpperCase();

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -20,6 +20,12 @@
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 13
 #endif
+// For 8-bit microcontrollers we should use 16 bit variables since the difficulty is low, for all the other cases should be 32 bits.
+#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
+typedef uint16_t uintDiff;
+#else
+typedef uint32_t uintDiff;
+#endif
 // Include SHA1 library
 // Authors: https://github.com/daknuett, https://github.com/JoyBed, https://github.com/revox
 // Improvements: https://github.com/joaquinbvw
@@ -31,13 +37,8 @@
 String lastblockhash = "";
 String newblockhash = "";
 String DUCOID = "";
-#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
-uint16_t difficulty = 0;
-uint16_t ducos1result = 0;
-#else
-uint32_t difficulty = 0;
-uint32_t ducos1result = 0;
-#endif
+uintDiff difficulty = 0;
+uintDiff ducos1result = 0;
 const uint16_t job_maxsize = 104; // 40+40+20+3 is the maximum size of a job
 uint8_t job[job_maxsize];
 
@@ -54,11 +55,7 @@ void setup() {
 }
 
 // DUCO-S1A hasher
-#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
-uint16_t ducos1a(String lastblockhash, String newblockhash, uint16_t difficulty)
-#else
-uint32_t ducos1a(String lastblockhash, String newblockhash, uint32_t difficulty)
-#endif
+uintDiff ducos1a(String lastblockhash, String newblockhash, uint16_t difficulty)
 {
   // DUCO-S1 algorithm implementation for AVR boards (DUCO-S1A)
   newblockhash.toUpperCase();
@@ -72,10 +69,8 @@ uint32_t ducos1a(String lastblockhash, String newblockhash, uint32_t difficulty)
   // If the difficulty is too high for AVR architecture then return 0
   if (difficulty > 655)
     return 0;
-  for (uint16_t ducos1res = 0; ducos1res < difficulty * 100 + 1; ducos1res++)
-  #else
-  for (uint32_t ducos1res = 0; ducos1res < difficulty * 100 + 1; ducos1res++)
   #endif
+  for (uintDiff ducos1res = 0; ducos1res < difficulty * 100 + 1; ducos1res++)
   {
     Sha1.init();
     Sha1.print(lastblockhash + String(ducos1res));

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -60,8 +60,8 @@ uintDiff ducos1a(String lastblockhash, String newblockhash, uint16_t difficulty)
   // DUCO-S1 algorithm implementation for AVR boards (DUCO-S1A)
   newblockhash.toUpperCase();
   const char *c = newblockhash.c_str();
-  size_t final_len = newblockhash.length() >> 1;
-  for (size_t i = 0, j = 0; j < final_len; i += 2, j++)
+  uint8_t final_len = newblockhash.length() >> 1;
+  for (uint8_t i = 0, j = 0; j < final_len; i += 2, j++)
     job[j] = ((((c[i] & 0x1F) + 9) % 25) << 4) + ((c[i + 1] & 0x1F) + 9) % 25;
 
   // Difficulty loop


### PR DESCRIPTION
Instead of including some #ifdef on the code we just use one #ifdef  and one typedef at the beginning to switch between architectures for choosing the bit size of the difficulty variables. Also I have changed the data type of a couple of variables to improve the performance a little bit.