### PR TITLE
Correcting os.system calls from python to python3

### DIFF
--- a/CLI_Wallet.py
+++ b/CLI_Wallet.py
@@ -258,7 +258,7 @@ while True:
                 + "It is probably under maintenance or temporarily down."
                 + "\nRetrying in 15 seconds.")
         time.sleep(15)
-        os.system("python " + __file__)
+        os.system("python3 " + __file__)
 
     except:
         print(Style.RESET_ALL
@@ -295,7 +295,7 @@ def reconnect():
                     + "It is probably under maintenance or temporarily down."
                     + "\nRetrying in 15 seconds.")
             time.sleep(15)
-            os.system("python " + __file__)
+            os.system("python3 " + __file__)
         else:
             return s
 
@@ -995,7 +995,7 @@ while True:
 
             elif command == "logout":
                 os.remove(RESOURCES_DIR + "/CLIWallet_config.cfg")
-                os.system("python " + __file__)
+                os.system("python3 " + __file__)
 
             elif command == "donate":
                 print(Style.RESET_ALL


### PR DESCRIPTION
Depending on python setups.
Those who only have python3 have error 
sh: 1: python: not found
simple fix to correct that on the os.system("python " + __file__ to os.system("python3 " + __file__