### PR TITLE
Changed the socket timeout and the port

### DIFF
--- a/Node.py
+++ b/Node.py
@@ -17,8 +17,8 @@ from datetime import datetime
 from traceback import format_exc
 
 
-SOCKET_TIMEOUT = 25
-NODE_PORT = 2810
+SOCKET_TIMEOUT = 100
+NODE_PORT = 2817
 DOCSTRING = """
          Please keep in mind that this 
          an early work in progress version to test the


### PR DESCRIPTION
It crashed regularly if it did not get a response in 25 seconds, Changing it to 100 lets it get a response but not crashing. At port 2810 sometimes the node would not connect and just crash.