### PR TITLE
Use infinity as max_hashrate in EXTREME difficulty

### DIFF
--- a/Master_Server/Server.py
+++ b/Master_Server/Server.py
@@ -316,7 +316,7 @@ def update_job_tiers():
             "EXTREME": {
                 "difficulty": int(1500000 * DIFF_MULTIPLIER),
                 "reward": 0,
-                "max_hashrate": 999999999
+                "max_hashrate": float("inf")
             },
             "XXHASH": {
                 "difficulty": int(100000 * DIFF_MULTIPLIER),


### PR DESCRIPTION
* Infinity is represented here as float("inf")
* This preserves "max_hashrate" semantics while removing the current hashrate limit of 1 GH/s for the EXTREME diff, which was exceeded by running nonceMiner on a GPU