### PR TITLE
Fix ambiguous overload error in esp8266 code

### DIFF
--- a/ESP8266_Code/ESP8266_Code.ino
+++ b/ESP8266_Code/ESP8266_Code.ino
@@ -63,7 +63,7 @@ void UpdateHostPort(String input) {
   deserializeJson(doc, input);
 
   const char* name = doc["name"];
-  host = String(doc["ip"]);
+  host = String((const char*)doc["ip"]);
   port = int(doc["port"]);
 
   Serial.println("Fetched pool: " + String(name) + " " + String(host) + " " + String(port));


### PR DESCRIPTION
a simple fix for the `error: ambiguous overload for 'operator=' (operand types are 'String' and >'ArduinoJson::JsonObjectSubscript<const char*>')` i was getting while compiling please merge kthxbye