### PR TITLE
Fixes #894 - uses pool list

### DIFF
--- a/ESP32_Code/ESP32_Code.ino
+++ b/ESP32_Code/ESP32_Code.ino
@@ -24,7 +24,7 @@ const char *username = "Your Duino-Coin username";
 const char *rig_identifier = "None";
 // Change this if your board has built-in led on non-standard pin
 #define LED_BUILTIN 2
-/ Define watchdog timer seconds
+// Define watchdog timer seconds
 #define WDT_TIMEOUT 60
 
 /* WARNING choosing the pool from the device will require at least 4k of dynamic memory on your board
@@ -155,7 +155,7 @@ void UpdateHostPort(String input) {
 // This is the 'new' functionality where the server returns all of the pools and the ESP will iterate through checking for the fastest connection.
 // All it does is sets the host/port global variables for the connection it chooses, then the threads kick in as normal after that
 String getPoolList() {
-	if(strlen(get_pool_list_api)) {
+	if(String(get_pool_list_api).length()) {
 		String pools = "";
 	
 		// Hard code a default for testing until we get a public URL
@@ -175,6 +175,7 @@ String getPoolList() {
 	
 		return pools;
 	}
+
 	String server = "server.duinocoin.com";
 	String uri = "/all_pools";
 	const char* root_ca = \
@@ -979,7 +980,7 @@ void MinerCheckinCode( void * pvParameters ) {
 	
 //	const char* apiUrl = "http://10.10.1.1/api/espCheckin.php"; // the URL of the checking API
 //
-//	unsigned long checkinDelay = 10000; // Check in to the IOT service every 10 seconds
+//	unsigned long checkinDelay = 2000; // Check in to the IOT service every 10 seconds
 //	unsigned long lastCheckin = 0;
 //	unsigned long lastShares = 0;
 //
@@ -1031,6 +1032,7 @@ void MinerCheckinCode( void * pvParameters ) {
 //			lastCheckin = millis();
 //			lastShares = shares_one + shares_two;
 //		}
+//		delay(100);
 //		yield();
 //	}
 }


### PR DESCRIPTION
Defaults to existing behaviour and code footprint.

Compile flag to switch behaviour, setting this to `true` will enable the pool connection checking 

```
#define USE_SERVER_CHOSEN_POOL true
```

Debug is in place to see more details about what's going on, it isn't a lot, but is disabled by default. Set this to `true` to enable it.

```
#define FIND_POOL_DEBUG false
```

The pool list contains some pool data, so there are a couple of tests performed before a connection attempt is made. A pool is skipped if the connections, RAM or RAM report zero (potential server failure) or are above limits (90% CPU/RAM or 10k connections). A connection is also skipped if the status flag is False.

limits are also variables

```
const int con_cap = 10000; // do not connect to servers with over this many connections
const float cpu_cap = 90; // do not connect to servers with over thisCPU in use
const float ram_cap = 90; // do not connect to servers with over this RAM in use
```

Due to the inclusion of SSL and a 4k JSON buffer to handle the pool list data, the sketch is quite big. The JSON buffer could be reduced to 2k, probably, if the number of pools isn't expected to grow much more, and RAM/CPU are integers.

```
Existing solution: Sketch uses 927881 bytes (70%) of program storage space. Maximum is 1310720 bytes.
New with no debug: Sketch uses 1086249 bytes (82%) of program storage space. Maximum is 1310720 bytes.
   New with debug: Sketch uses 1088413 bytes (83%) of program storage space. Maximum is 1310720 bytes.
```