### PR TITLE
ESP32 OTA working

### DIFF
--- a/ESP32_Code/ESP32_Code.ino
+++ b/ESP32_Code/ESP32_Code.ino
@@ -629,6 +629,7 @@ void setup() {
       .onEnd([]() { Serial.println(F("\nEnd")); })
       .onProgress([](unsigned int progress, unsigned int total) {
         Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+        esp_task_wdt_reset();
         ota_state = true;
       })
       .onError([](ota_error_t error) {


### PR DESCRIPTION
It seems when the OTA stuff kicks in the watchdog timer is not reset causing it to restart before the upload has concluded. This seems to make the upload a lot faster as well - totally subjective, but the upload completed the 6 times I tried it after the change and zero before.