### PR TITLE
Update AVR_Miner.py

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -431,7 +431,7 @@ def load_config():
             donation_level = 5
         if float(donation_level) < int(0):
             donation_level = 0
-        donation_level=int(donation_level)
+        donation_level = int(donation_level)
 
         config["AVR Miner"] = {
             'username':         username,

--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -431,11 +431,12 @@ def load_config():
             donation_level = 5
         if float(donation_level) < int(0):
             donation_level = 0
+        donation_level=int(donation_level)
 
         config["AVR Miner"] = {
             'username':         username,
             'avrport':          avrport,
-            'donate':           int(donation_level),
+            'donate':           donation_level,
             'language':         lang,
             'identifier':       rig_identifier,
             'debug':            'n',
@@ -912,8 +913,8 @@ if __name__ == '__main__':
 
     if donation_level > 0:
         try:
-            Donate.load(int(donation_level))
-            Donate.start(int(donation_level))
+            Donate.load(donation_level)
+            Donate.start(donation_level)
         except Exception as e:
             debug_output(f'Error launching donation thread: {e}')
 


### PR DESCRIPTION
Fixed donation_level conversion error, pointed on https://github.com/revoxhere/duino-coin/issues/991 the error it's on another conversion because of this the commit https://github.com/revoxhere/duino-coin/commit/fc89b67e4086cbd5c3bb64e420d4235b1669b381 didnt't resolve it

```
Traceback (most recent call last):
  File "AVR_Miner.py", line 913, in <module>
    if donation_level > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
```