### PR TITLE
Add Emoji support for new Windows Terminal

### DIFF
--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -121,7 +121,7 @@ class Settings:
     BLOCK = " ‖ "
     PICK = ""
     COG = " @"
-    if os.name != "nt":
+    if os.name != "nt" or bool(os.name == "nt" and os.environ.get("WT_SESSION")):
         # Windows' cmd does not support emojis, shame!
         PICK = " ⛏"
         COG = " ⚙"


### PR DESCRIPTION
The new Windows Terminal (https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701) supports emojis!! This addition checks if there is a WT_SESSION environment variable set (the current session for the windows terminal) or the os is not windows. I have tested this on Microsoft Windows 11 Home 10.0.22000, Ubuntu 21.04 (GNU/Linux 5.11.0-1017-raspi aarch64) and the latest Kali Linux docker image.