### PR TITLE
Catch set_title exception when running bash as a background process

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -213,7 +213,7 @@ class Donate:
                          'warning')
 
 
-shares = [0, 0]
+shares = [0, 0, 0]
 hashrate_mean = []
 ping_mean = []
 diff = 0
@@ -675,6 +675,7 @@ def mine_avr(com, threadid, fastest_pool):
     global hashrate
     start_time = time()
     report_shares = 0
+    last_report_share = 0
     while True:
         while True:
             try:
@@ -868,6 +869,7 @@ def mine_avr(com, threadid, fastest_pool):
                 printlock.release()
             elif feedback == 'BLOCK':
                 shares[0] += 1
+                shares[2] += 1
                 printlock.acquire()
                 share_print(port_num(com), "block",
                             shares[0], shares[1], hashrate,
@@ -888,16 +890,17 @@ def mine_avr(com, threadid, fastest_pool):
             end_time = time()
             elapsed_time = end_time - start_time
             if threadid == 0 and elapsed_time >= Settings.REPORT_TIME:
-                report_shares = shares[0] - report_shares
+                report_shares = shares[0] - last_report_share
                 uptime = calculate_uptime(mining_start_time)
 
                 periodic_report(start_time, end_time, report_shares,
-                                hashrate, uptime)
+                                shares[2], hashrate, uptime)
                 start_time = time()
+                last_report_share = shares[0]
 
 
 def periodic_report(start_time, end_time, shares,
-                    hashrate, uptime):
+                    block, hashrate, uptime):
     seconds = round(end_time - start_time)
     pretty_print("sys0",
                  " " + get_string('periodic_mining_report')
@@ -907,7 +910,9 @@ def periodic_report(start_time, end_time, shares,
                  + get_string('report_body1')
                  + str(shares) + get_string('report_body2')
                  + str(round(shares/seconds, 1))
-                 + get_string('report_body3') + get_string('report_body4')
+                 + get_string('report_body3')
+                 + get_string('report_body7') + str(block)
+                 + get_string('report_body4')
                  + str(int(hashrate)) + " H/s" + get_string('report_body5')
                  + str(int(hashrate*seconds)) + get_string('report_body6')
                  + get_string('total_mining_time') + str(uptime), "success")


### PR DESCRIPTION
Set title throws an exception when running a bash background process, so, for example, in my setup I start a bash process that starts AVR_Miner.py on the Raspberry Pi boot by adding an entry to /etc/rc.local and the script throws an exception when trying to update the title.