### PR TITLE
Replace mineuino with Duinotize

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Server source code, documentation for API calls and official libraries for devel
   *   [STM8 DUCO Miner](https://github.com/BBS215/STM8_DUCO_miner) - STM8S firmware for mining DUCO by BBS215
   *   [DuinoCoinbyLabVIEW](https://github.com/ericddm/DuinoCoinbyLabVIEW) - miner for LabVIEW family by ericddm
   *   [Duino-JS](https://github.com/Hoiboy19/Duino-JS) - a JavaScript miner which you can easily implement in your site by Hoiboy19
-  *   [Mineuino](https://github.com/VatsaDev/Mineuino) - website monetizer by VatsaDev
+  *   [Duinotize](https://github.com/mobilegmYT/Duinotize) - Duino website monetizer by mobilegmYT
   *   [hauchel's duco-related stuff repository](https://github.com/hauchel/duco/) - Collection of various codes for mining DUCO on other microcontrollers
   *   [duino-coin-php-miner](https://github.com/ricardofiorani/duino-coin-php-miner) Dockerized Miner in PHP by ricardofiorani
   *   [duino-coin-kodi](https://github.com/SandUhrGucker/duino-coin-kodi) - Mining addon for Kodi Media Center by SandUhrGucker


### PR DESCRIPTION
Mineuino seems to be abandoned by it's creator and it uses the wrong server URL, so I forked it and got it to work by adding some of the web miner code to it.

You can see my code in action if you visit https://www.amogos.studio/ and open the dev console.