### PR TITLE
Add settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+Duino-Coin PC Miner 3.4/Settings.cfg


### PR DESCRIPTION
Prevents mistakenly posting miner settings (possibly mining key)