### PR TITLE
fixed update question issue

### DIFF
--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -198,7 +198,7 @@ def check_updates():
 
         if float(Settings.VER) < float(data["tag_name"]): # If is outdated
             update = input(Style.BRIGHT + get_string("new_version"))
-            if update == "Y" or update == "y":
+            if update.lower() == "y" or update == "":
                 pretty_print(get_string("updating"), "warning", "sys0")
 
                 DATA_DIR = "Duino-Coin PC Miner " + str(data["tag_name"]) # Create new version config folder


### PR DESCRIPTION
The program says `A new version is available, you want to update miner (Y/n) ?` after not entering anything the program should install the update, which it does not. It's commonly understood that the letter that is capital means that that is the default answer, which I thought was the case here.