### PR TITLE
Fix typo in Portuguese translation

### DIFF
--- a/Resources/PC_Miner_langs.json
+++ b/Resources/PC_Miner_langs.json
@@ -1265,7 +1265,7 @@
         "donate_warning": "\nNão recebemos nada pela sua mineração.\nSe quiser nos ajudar, doe em nosso site.\nVisite ",
         "learn_more_donate": " para saber como nos ajudar :)",
         "starting_donation": "Iniciando o processo de doação.",
-        "thanks_donation": " Obrigado por doar ❤️ Seu apoio, idependente do tamanho ajuda muito.",
+        "thanks_donation": " Obrigado por doar ❤️ Seu apoio, independente do tamanho ajuda muito.",
         "data_error": " Erro ao tentar extrair os arquivos do GitHub! Tentando novamente em 10s.",
         "connected": " Conectado",
         "connected_server": " servidor principal do Duino-Coin (v",


### PR DESCRIPTION
Fixed a misspelled Portuguese word (idependente -> indenpendente)