### PR TITLE
Arduino_Code: fix include case

### DIFF
--- a/Arduino_Code/duco_hash.h
+++ b/Arduino_Code/duco_hash.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 #define SHA1_BLOCK_LEN 64
 #define SHA1_HASH_LEN 20


### PR DESCRIPTION
Hello,

This PR aims at fixing the compilation of `Arduino_Code` on case-sensitive filesystems (like the ones in Linux).

For instance, when compiling on Ubuntu 23.04 x86\_64, we can see:

```bash
# The compilation fails
$ arduino-cli compile -b arduino:avr:uno Arduino_Code
In file included from /home/.../workspace/duino-coin/Arduino_Code/Arduino_Code.ino:33:0:
/home/.../workspace/duino-coin/Arduino_Code/duco_hash.h:3:10: fatal error: arduino.h: No such file or directory
 #include <arduino.h>
          ^~~~~~~~~~~
compilation terminated.


Used platform Version Path                                                     
arduino:avr   1.8.6   /home/.../.arduino15/packages/arduino/hardware/avr/1.8.6

# The file is actually Arduino.h, with a capital letter
$ find ~/.arduino15/packages/arduino/hardware/avr/1.8.6/cores -iname arduino.h  
/home/.../.arduino15/packages/arduino/hardware/avr/1.8.6/cores/arduino/Arduino.h
```

When applying the patch:

```bash
$ arduino-cli compile -b arduino:avr:uno Arduino_Code
Sketch uses 12812 bytes (39%) of program storage space. Maximum is 32256 bytes.
Global variables use 437 bytes (21%) of dynamic memory, leaving 1611 bytes for local variables. Maximum is 2048 bytes.

Used platform Version Path                                                     
arduino:avr   1.8.6   /home/.../.arduino15/packages/arduino/hardware/avr/1.8.6
```

Thanks for this fun project !