### PR TITLE
Fix compile error

### DIFF
--- a/ESP_Code/ESP_Code.ino
+++ b/ESP_Code/ESP_Code.ino
@@ -34,6 +34,7 @@
     #include <ESP8266WebServer.h>
 #else
     #include <ESPmDNS.h>
+    #include <WiFiClientSecure.h>
     #include <WiFi.h>
     #include <HTTPClient.h>
     #include <WebServer.h>


### PR DESCRIPTION
Fixed this compile error: `'WiFiClientSecure' was not declared in this scope; did you mean 'WiFiClient'?` on ESP32