### PR TITLE
Update ESP_Code.ino

### DIFF
--- a/ESP_Code/ESP_Code.ino
+++ b/ESP_Code/ESP_Code.ino
@@ -347,7 +347,7 @@ namespace {
                 wait_passes = 0;
             }
         }
-        #ifndef(ESP8266)
+        #if !defined(ESP8266)
               WiFi.config(WiFi.localIP(), WiFi.gatewayIP(), WiFi.subnetMask(), DNS_SERVER);
         #endif
 


### PR DESCRIPTION
Fix the error ESP_CODE:350_16: error: macro names must be identifiers