### PR TITLE
bugfix: bring rig id to the dashboard for blushy boxes

### DIFF
--- a/ESP_Code/ESP_Code.ino
+++ b/ESP_Code/ESP_Code.ino
@@ -649,6 +649,7 @@ void setup() {
         configuration->DUCO_USER = duco_username;
         configuration->RIG_IDENTIFIER = duco_rigid;
         configuration->MINER_KEY = duco_password;
+        RIG_IDENTIFIER = duco_rigid;
 
         String captivePortalHTML = R"(
           <title>Duino BlushyBox</title>


### PR DESCRIPTION
I bought a BlushyBox and in the dashboard was the rig name not shown. So I fixed it. BTW Duco-Name is Topsider ;-)
We had a discussion in Discord about updating the BlushyBox with OTA.