### PR TITLE
Updated Terms to include a ban on VPNs and Proxies

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -253,7 +253,7 @@
             <br><br><br>
             <div class="content">
                 <p class="title">Duino-Coin Terms of Service</p>
-                <p class="subtitle">Last updated and effective: August 7, 2023</p>
+                <p class="subtitle">Last updated and effective: January 5, 2025</p>
                 <br/>
                 <h2 class="subtitle">Welcome to Duino-Coin!</h2>
                 <p>Thank you for using Duino-Coin! Thank you for using our services. By using Duino-Coin ("DUCO"), you agree to abide by the following Terms of Service. These terms govern your use of the Duino-Coin network, mining process, and the official Duino-Coin Exchange. Please read them carefully before using our services.</p>
@@ -281,43 +281,46 @@
                 <h2 class="subtitle">4. Alt Accounts</h2>
                 <p>Alt accounts are strictly prohibited and are not allowed.</p>
                 <br/>
-                <h2 class="subtitle">5. Prohibited Transactions</h2>
+        		<h2 class="subtitle">5. VPN and Proxy Services </h2>
+        		<p>The usage of any VPN or proxy service or any other service, which hides the client's true IP address, is forbidden. Offenses may result in a flagging or a permanent suspension of the offending account. </p>
+        		<br/>
+                <h2 class="subtitle">6. Prohibited Transactions</h2>
                 <p>Sending transactions that promote other services or advertise something in any form is not allowed. Such transactions may result in the suspension or blocking of the user's account.</p>
                 <br/>
-                <h2 class="subtitle">6. Transaction Rate Limiting</h2>
+                <h2 class="subtitle">7. Transaction Rate Limiting</h2>
                 <p>Sending a lot of transactions in a short amount of time can trigger the Kolka system, which will rate limit and/or block the user.</p>
                 <br/>
-                <h2 class="subtitle">7. Community-Made Software</h2>
+                <h2 class="subtitle">8. Community-Made Software</h2>
                 <p>Community-made software needs to comply with the rules (terms of service, difficulty tiers, etc.). Abusing the system will lead to blocking of the software and/or the user(s).</p>
                 <br/>
-                <h2 class="subtitle">8. Account Usage and Impersonation</h2>
+                <h2 class="subtitle">9. Account Usage and Impersonation</h2>
                 <p>Accounts proven to be misleading in name or usage (impersonation, fake bots, etc.) are not allowed.</p>
                 <br/>
-                <h2 class="subtitle">9. Offensive Verification Pictures</h2>
+                <h2 class="subtitle">10. Offensive Verification Pictures</h2>
                 <p>Sending an offensive and/or unrelated verification picture and/or description will lead to immediate blocking of the account.</p>
                 <br/>
-                <h2 class="subtitle">10. Intellectual Property and Logo Usage</h2>
+                <h2 class="subtitle">11. Intellectual Property and Logo Usage</h2>
                 <ul>
                     <li><strong>Intellectual Property:</strong> Duino-Coin retains all rights, title, and interest in and to the Duino-Coin network, software, logo, and all related intellectual property. Unauthorized use, reproduction, or distribution of Duino-Coin's intellectual property is strictly prohibited.</li>
                     <li><strong>Intellectual Property Usage:</strong> Duino-Coin allows the use of certian intellectual properties in documentation, entertainment (videos/blogs), and other non-commercial purposes, provided proper attribution is given (this can be in the form of a link back to duinocoin.com). Click <a href="https://github.com/revoxhere/duino-coin/tree/useful-tools#branding">here</a> to see our public branding package.</li>
                 </ul>
                 <br/>
-                <h2 class="subtitle">11. Third-Party Links</h2>
+                <h2 class="subtitle">12. Third-Party Links</h2>
                 <p>Our site or services may contain links to third-party websites or services that are not owned or controlled by Duino-Coin. Duino-Coin assumes no responsibility for the content, privacy policies, or practices of any third-party websites or services. Users acknowledge and agree that Duino-Coin shall not be responsible or liable for any damage or loss caused by or in connection with the use of or reliance on any such content, goods, or services available through third-party websites or services.</p>
                 <br/>
-                <h2 class="subtitle">12. Limitation of Liability</h2>
+                <h2 class="subtitle">13. Limitation of Liability</h2>
                 <p>The Duino-Coin network's code is open-source, provided on an "as is" basis, without warranties or conditions of any kind. Duino-Coin shall not be liable for any direct, indirect, incidental, special, consequential, or exemplary damages, including but not limited to damages for loss of profits, goodwill, use, data, or other intangible losses, resulting from the use or inability to use the Duino-Coin network or its software.</p>
                 <br/>
-                <h2 class="subtitle">13. Disclaimer</h2>
+                <h2 class="subtitle">14. Disclaimer</h2>
                 <p>Please review our <a href="https://duinocoin.com/disclaimer">Disclaimer</a> for important information about the value, trading, and use of DUCO and wDUCO assets, as well as the risks associated with using our services and platforms.</p>
                 <br/>
-                <h2 class="subtitle">14. Termination of Services</h2>
+                <h2 class="subtitle">15. Termination of Services</h2>
                 <p>Duino-Coin reserves the right to terminate or suspend any user's access to the Duino-Coin network at any time, without prior notice, for any reason, or for no reason, in its sole discretion.</p>
                 <br/>
-                <h2 id="subtitle">15. Changes to the Terms of Service</h2>
+                <h2 id="subtitle">16. Changes to the Terms of Service</h2>
                 <p>These Terms of Service may be changed or updated at any time without prior notice. Users are responsible for regularly reviewing the latest version. Continued use of the Service after any modifications to the Terms of Service constitutes acceptance of the updated terms.</p>
                 <br/>
-                <h2 class="subtitle">16. Contact Us</h2>
+                <h2 class="subtitle">17. Contact Us</h2>
                 <p>If you have any questions or concerns regarding these Terms of Service or need further clarification, please don't hesitate to contact us <a href="https://duinocoin.com/contact">here</a>.</p>
                 <br/>
                 <p>Thank you for being a part of the Duino-Coin community!</p>

--- a/terms.html
+++ b/terms.html
@@ -281,9 +281,9 @@
                 <h2 class="subtitle">4. Alt Accounts</h2>
                 <p>Alt accounts are strictly prohibited and are not allowed.</p>
                 <br/>
-        		<h2 class="subtitle">5. VPN and Proxy Services </h2>
-        		<p>The usage of any VPN or proxy service or any other service, which hides the client's true IP address, is forbidden. Offenses may result in a flagging or a permanent suspension of the offending account. </p>
-        		<br/>
+                <h2 class="subtitle">5. VPN and Proxy Services </h2>
+                <p>The usage of any VPN or proxy service or any other service, which hides the client's true IP address, is forbidden. Offenses may result in a flagging or a permanent suspension of the offending account. </p>
+                <br/>
                 <h2 class="subtitle">6. Prohibited Transactions</h2>
                 <p>Sending transactions that promote other services or advertise something in any form is not allowed. Such transactions may result in the suspension or blocking of the user's account.</p>
                 <br/>


### PR DESCRIPTION
The team currently has had an inofficial rule that VPNs and Proxies are disallowed (due to the current workings/limitations of the alt detection system).

Therefore, I updated the ToS to include the ban on any such services (placed as num 5)