### PR TITLE
Add info & support for several boards

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -990,6 +990,13 @@ def mine_avr(com, threadid, fastest_pool, thread_rigid):
                 receiving the DTR signal
                 """
                 sleep(2)
+
+                """
+                Indicate to the device that the port
+                is open for receiving data after
+                reseting the board
+                """
+                ser.setRTS(False)
                 break
             except Exception as e:
                 pretty_print(

--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -1106,7 +1106,7 @@ def mine_avr(com, threadid, fastest_pool, thread_rigid):
             break
 
         start_diff = "AVR"
-        if hashrate_test > 1000:
+        if hashrate_test > 3500:
             start_diff = "DUE"
         elif hashrate_test > 550:
             start_diff = "ARM"

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -31,13 +31,6 @@ for default settings use -O0. -O may be a good tradeoff between both */
 #define SEP_TOKEN ","
 #define END_TOKEN "\n"
 
-/* For 8-bit microcontrollers we should use 16 bit variables since the
-difficulty is low, for all the other cases should be 32 bits. */
-#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
-typedef uint32_t uintDiff;
-#else
-typedef uint32_t uintDiff;
-#endif
 // Arduino identifier library - https://github.com/ricaun
 #include "uniqueID.h"
 
@@ -48,7 +41,7 @@ typedef uint32_t uintDiff;
 
 bool digitDrawn = false;
 bool matrixEnabled = true;
-int minedDigitCount = 0;
+byte minedDigitCount = 0;
 
 Adafruit_Microbit_Matrix microbit;
 #endif
@@ -102,7 +95,7 @@ void lowercase_hex_to_bytes(char const * hexDigest, uint8_t * rawDigest) {
 }
 
 // DUCO-S1A hasher
-uintDiff ducos1a(char const * prevBlockHash, char const * targetBlockHash, uintDiff difficulty) {
+uint32_t ducos1a(char const * prevBlockHash, char const * targetBlockHash, uint32_t difficulty) {
   #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
     // If the difficulty is too high for AVR architecture then return 0
     if (difficulty > 655) return 0;
@@ -111,16 +104,16 @@ uintDiff ducos1a(char const * prevBlockHash, char const * targetBlockHash, uintD
   uint8_t target[SHA1_HASH_LEN];
   lowercase_hex_to_bytes(targetBlockHash, target);
 
-  uintDiff const maxNonce = difficulty * 100 + 1;
+  uint32_t const maxNonce = difficulty * 100 + 1;
   return ducos1a_mine(prevBlockHash, target, maxNonce);
 }
 
-uintDiff ducos1a_mine(char const * prevBlockHash, uint8_t const * target, uintDiff maxNonce) {
+uint32_t ducos1a_mine(char const * prevBlockHash, uint8_t const * target, uint32_t maxNonce) {
   static duco_hash_state_t hash;
   duco_hash_init(&hash, prevBlockHash);
 
   char nonceStr[10 + 1];
-  for (uintDiff nonce = 0; nonce < maxNonce; nonce++) {
+  for (uint32_t nonce = 0; nonce < maxNonce; nonce++) {
     ultoa(nonce, nonceStr, 10);
 
     uint8_t const * hash_bytes = duco_hash_try_nonce(&hash, nonceStr);
@@ -174,7 +167,7 @@ void loop() {
   newBlockHash[40] = 0;
 
   // Read difficulty
-  uintDiff difficulty = strtoul(Serial.readStringUntil(',').c_str(), NULL, 10);
+  uint32_t difficulty = strtoul(Serial.readStringUntil(',').c_str(), NULL, 10);
   // Clearing the receive buffer reading one job.
   while (Serial.available()) Serial.read();
   // Turn off the built-in led
@@ -188,7 +181,7 @@ void loop() {
   uint32_t startTime = micros();
 
   // Call DUCO-S1A hasher
-  uintDiff ducos1result = ducos1a(lastBlockHash, newBlockHash, difficulty);
+  uint32_t ducos1result = ducos1a(lastBlockHash, newBlockHash, difficulty);
 
   // Calculate elapsed time
   uint32_t elapsedTime = micros() - startTime;

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -108,23 +108,19 @@ void lowercase_hex_to_bytes(char const * hexDigest, uint8_t * rawDigest) {
 }
 
 // DUCO-S1A hasher
-uint32_t ducos1a(char const * prevBlockHash, char const * targetBlockHash, uint32_t difficulty) {
+uint32_t ducos1a() {
   #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
     // If the difficulty is too high for AVR architecture then return 0
-    if (difficulty > 655) return 0;
+    if (job->difficulty > 655) return 0;
   #endif
 
   uint8_t target[SHA1_HASH_LEN];
-  lowercase_hex_to_bytes(targetBlockHash, target);
+  lowercase_hex_to_bytes(job->newBlockHash, target);
 
-  uint32_t const maxNonce = difficulty * 100 + 1;
-  return ducos1a_mine(prevBlockHash, target, maxNonce);
-}
-
-uint32_t ducos1a_mine(char const * prevBlockHash, uint8_t const * target, uint32_t maxNonce) {
   static duco_hash_state_t hash;
-  duco_hash_init(&hash, prevBlockHash);
+  duco_hash_init(&hash, job->lastBlockHash);
 
+  uint32_t const maxNonce = job->difficulty * 100 + 1;
   char nonceStr[10 + 1];
   for (uint32_t nonce = 0; nonce < maxNonce; nonce++) {
     ultoa(nonce, nonceStr, 10);
@@ -187,7 +183,7 @@ void hashEvent() {
   uint32_t startTime = micros();
 
   // Call DUCO-S1A hasher
-  uint32_t ducos1result = ducos1a(job->lastBlockHash, job->newBlockHash, job->difficulty);
+  uint32_t ducos1result = ducos1a();
 
   // Calculate elapsed time
   uint32_t elapsedTime = micros() - startTime;

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -17,6 +17,12 @@
 for default settings use -O0. -O may be a good tradeoff between both */
 #pragma GCC optimize ("-Ofast")
 
+/* Pull in non-standard functions */
+#if __has_include(<stdlib_noniso.h>)
+#include <stdlib_noniso.h>
+#endif
+
+
 /* For microcontrollers with custom LED pins, adjust the line below */
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 13

--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -6,7 +6,7 @@
   (____/(______)(____)(_)\_)(_____)     \___)(_____)(____)(_)\_)
   Official code for Arduino boards (and relatives)   version 4.3
   
-  Duino-Coin Team & Community 2019-2024 © MIT Licensed
+  Duino-Coin Team & Community 2019-2025 © MIT Licensed
   https://duinocoin.com
   https://github.com/revoxhere/duino-coin
   If you don't know where to start, visit official website and navigate to

--- a/Arduino_Code/uniqueID.cpp
+++ b/Arduino_Code/uniqueID.cpp
@@ -183,6 +183,16 @@ ArduinoUniqueID::ArduinoUniqueID()
   id[7] = SIGROW.SERNUM7;
   id[8] = SIGROW.SERNUM8;
   id[9] = SIGROW.SERNUM9;
+#elif defined(NRF51_SERIES) || defined(NRF52_SERIES) || defined(NRF53_SERIES)
+  NRF_FICR_Type ficr = *NRF_FICR;
+  id[0] = ficr.DEVICEID[0] >> 24;
+  id[1] = ficr.DEVICEID[0] >> 16;
+  id[2] = ficr.DEVICEID[0] >> 8;
+  id[3] = ficr.DEVICEID[0];
+  id[4] = ficr.DEVICEID[1] >> 24;
+  id[5] = ficr.DEVICEID[1] >> 16;
+  id[6] = ficr.DEVICEID[1] >> 8;
+  id[7] = ficr.DEVICEID[1];
 #endif
 }
 

--- a/Arduino_Code/uniqueID.h
+++ b/Arduino_Code/uniqueID.h
@@ -22,8 +22,9 @@
 #elif defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
 //#include <pico/unique_id.h>
 #elif defined(ARDUINO_ARCH_MEGAAVR)
+#elif defined(NRF51_SERIES) || defined(NRF52_SERIES) || defined(NRF53_SERIES)
 #else
-#error "ArduinoUniqueID only works on AVR, SAM, SAMD, STM32, Teensy, megaAVR and ESP Architecture"
+#error "ArduinoUniqueID only works on AVR, SAM, SAMD, STM32, Teensy, megaAVR, nRF5 and ESP Architecture"
 #endif
 
 #if defined(ARDUINO_ARCH_AVR)
@@ -63,6 +64,9 @@
 #elif defined(ARDUINO_ARCH_MEGAAVR)
 #define UniqueIDsize 10
 #define UniqueIDbuffer 10
+#elif defined(NRF51_SERIES) || defined(NRF52_SERIES) || defined(NRF53_SERIES)
+#define UniqueIDsize 8
+#define UniqueIDbuffer 8
 #endif
 
 #define UniqueID8 (_UniqueID.id + UniqueIDbuffer - 8)

--- a/README.md
+++ b/README.md
@@ -167,16 +167,24 @@ Please note the DUCO/day column has been removed since version 4.0 changed the r
 | Libre Computers Tritium H5CC                              | 480 kH/s                          | 4                 | 5 W            |
 | Libre Computers Le Potato                                 | 410 kH/s                          | 4                 | 5 W            |
 | Pine64 ROCK64                                             | 640 kH/s                          | 4                 | 5 W            |
+| Qualcomm Snapdragon 425 **(fasthash)**                    | 6.4 MH/s                          | 4                 | 3.5 W          |
+| Qualcomm Snapdragon 615                                   | 225 KH/s                          | 4                 | 3.5 W          |
+| Qualcomm Snapdragon 8 Gen 1 **(fasthash)**                | 27.6 MH/s                         | 8                 | 5 W            |
+| MediaTek Helio A22 **(fasthash)**                         | 9.3 MH/s                          | 4                 | 4.5 W          |
 | Intel Celeron G1840                                       | 1.25 MH/s                         | 2                 | 53 W           |
+| Intel Celeron N2840 **(fasthash)**                        | 4.4 MH/s                          | 2                 | 2.2 W          |
+| Intel Core m3-8100Y **(fasthash)**                        | 11.0 MH/s                         | 4                 | 8.1 W          |
+| Intel Core i3-4130                                        | 1.45 MH/s                         | 4                 | 54 W           |
 | Intel Core i5-2430M                                       | 1.18 MH/s                         | 4                 | 35 W           |
 | Intel Core i5-3230M                                       | 1.52 MH/s                         | 4                 | 35 W           |
 | Intel Core i5-5350U                                       | 1.35 MH/s                         | 4                 | 15 W           |
 | Intel Core i5-7200U                                       | 1.62 MH/s                         | 4                 | 15 W           |
 | Intel Core i5-8300H                                       | 3.67 MH/s                         | 8                 | 45 W           |
-| Intel Core i3-4130                                        | 1.45 MH/s                         | 4                 | 54 W           |
+| Intel Core i7-11370H **(fasthash)**                       | 17.3 MH/s                         | 8                 | 35 W           |
+| Intel Core i7-1260P **(fasthash)**                        | 73.5 MH/s                         | 16                | 25 W           |
+| Intel Core i9-13900K **(fasthash)**                       | 104.04 MH/s                       | 32                | 160 W          |
 | AMD Ryzen 5 2600                                          | 4.9 MH/s                          | 12                | 65 W           |
 | AMD Ryzen R1505G **(fasthash)**                           | 8.5 MH/s                          | 4                 | 35 W           |
-| Intel Core i7-11370H **(fasthash)**                       | 17.3 MH/s                         | 8                 | 35 W           |
 | Realtek RTD1295                                           | 490 kH/s                          | 4                 | -              |
 | Realtek RTD1295 **(fasthash)**                            | 3.89 MH/s                         | 4                 | -              |
 

--- a/Unofficial miners/W80x_Code/W80x_Code.ino
+++ b/Unofficial miners/W80x_Code/W80x_Code.ino
@@ -12,8 +12,8 @@ for default settings use -O0. -O may be a good tradeoff between both */
 
 /* Sets the LED pins, adjust if necessary */
 #ifdef LED_BUILTIN
-#define LED_WAITING LED_BUILTIN_3
-#define LED_HASHING LED_BUILTIN_2
+#define LED_IDLE LED_BUILTIN_2
+#define LED_HASHING LED_BUILTIN_3
 #endif
 
 #define SEP_TOKEN ","
@@ -35,7 +35,7 @@ String DUCOID = "";
 
 void setup() {
   // Prepare built-in led pins as output
-  pinMode(LED_WAITING, OUTPUT);
+  pinMode(LED_IDLE, OUTPUT);
   pinMode(LED_HASHING, OUTPUT);
 
   DUCOID = get_DUCOID();
@@ -91,13 +91,13 @@ uintDiff ducos1a_mine(char const * prevBlockHash, uint8_t const * target, uintDi
 void loop() {
   // Wait for serial data
   if (Serial.available() <= 0) {
-    digitalWrite(LED_WAITING, HIGH);
+    digitalWrite(LED_IDLE, HIGH);
     digitalWrite(LED_HASHING, LOW);
     return;
   }
 
   // Update led state for hashing
-  digitalWrite(LED_WAITING, LOW);
+  digitalWrite(LED_IDLE, LOW);
   digitalWrite(LED_HASHING, HIGH);
 
   // Reserve 1 extra byte for comma separator (and later zero)

--- a/Unofficial miners/W80x_Code/W80x_Code.ino
+++ b/Unofficial miners/W80x_Code/W80x_Code.ino
@@ -1,0 +1,144 @@
+// Copyright (C) 2019-2025 Duino-Coin Community
+// SPDX-License-Identifier: MIT
+
+/* For microcontrollers with low memory change that to -Os in all files,
+for default settings use -O0. -O may be a good tradeoff between both */
+#pragma GCC optimize ("-Ofast")
+
+#include <Arduino.h>
+#include <stdlib_noniso.h>
+#include "w80xID.h"
+#include "duco_hash.h"
+
+/* Sets the LED pins, adjust if necessary */
+#ifdef LED_BUILTIN
+#define LED_WAITING LED_BUILTIN_3
+#define LED_HASHING LED_BUILTIN_2
+#endif
+
+#define SEP_TOKEN ","
+#define END_TOKEN "\n"
+
+typedef uint32_t uintDiff;
+
+String get_DUCOID() {
+  String ID = "DUCOID";
+  char buff[4];
+  for (size_t i = 0; i < 8; i++) {
+    sprintf(buff, "%02X", (uint8_t)UniqueID8[i]);
+    ID += buff;
+  }
+  return ID;
+}
+
+String DUCOID = "";
+
+void setup() {
+  // Prepare built-in led pins as output
+  pinMode(LED_WAITING, OUTPUT);
+  pinMode(LED_HASHING, OUTPUT);
+
+  DUCOID = get_DUCOID();
+  // Open serial port
+  Serial.begin(115200);
+  Serial.setTimeout(10000);
+}
+
+void lowercase_hex_to_bytes(char const * hexDigest, uint8_t * rawDigest) {
+  for (uint8_t i = 0, j = 0; j < SHA1_HASH_LEN; i += 2, j += 1) {
+    uint8_t x = hexDigest[i];
+    uint8_t b = x >> 6;
+    uint8_t r = ((x & 0xf) | (b << 3)) + b;
+
+    x = hexDigest[i + 1];
+    b = x >> 6;
+
+    rawDigest[j] = (r << 4) | (((x & 0xf) | (b << 3)) + b);
+  }
+}
+
+// DUCO-S1A hasher
+uintDiff ducos1a(char const * prevBlockHash, char const * targetBlockHash, uintDiff difficulty) {
+  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
+    // If the difficulty is too high for AVR architecture then return 0
+    if (difficulty > 655) return 0;
+  #endif
+
+  uint8_t target[SHA1_HASH_LEN];
+  lowercase_hex_to_bytes(targetBlockHash, target);
+
+  uintDiff const maxNonce = difficulty * 100 + 1;
+  return ducos1a_mine(prevBlockHash, target, maxNonce);
+}
+
+uintDiff ducos1a_mine(char const * prevBlockHash, uint8_t const * target, uintDiff maxNonce) {
+  static duco_hash_state_t hash;
+  duco_hash_init(&hash, prevBlockHash);
+
+  char nonceStr[10 + 1];
+  for (uintDiff nonce = 0; nonce < maxNonce; nonce++) {
+    ultoa(nonce, nonceStr, 10);
+
+    uint8_t const * hash_bytes = duco_hash_try_nonce(&hash, nonceStr);
+    if (memcmp(hash_bytes, target, SHA1_HASH_LEN) == 0) {
+      return nonce;
+    }
+  }
+
+  return 0;
+}
+
+void loop() {
+  // Wait for serial data
+  if (Serial.available() <= 0) {
+    digitalWrite(LED_WAITING, HIGH);
+    digitalWrite(LED_HASHING, LOW);
+    return;
+  }
+
+  // Update led state for hashing
+  digitalWrite(LED_WAITING, LOW);
+  digitalWrite(LED_HASHING, HIGH);
+
+  // Reserve 1 extra byte for comma separator (and later zero)
+  char lastBlockHash[40 + 1];
+  char newBlockHash[40 + 1];
+
+  // Read last block hash
+  if (Serial.readBytesUntil(',', lastBlockHash, 41) != 40) {
+    return;
+  }
+  lastBlockHash[40] = 0;
+
+  // Read expected hash
+  if (Serial.readBytesUntil(',', newBlockHash, 41) != 40) {
+    return;
+  }
+  newBlockHash[40] = 0;
+
+  // Read difficulty
+  uintDiff difficulty = strtoul(Serial.readStringUntil(',').c_str(), NULL, 10);
+
+  // Clearing the receive buffer reading one job.
+  while (Serial.available()) Serial.read();
+
+  // Start time measurement
+  uint32_t startTime = micros();
+
+  // Call DUCO-S1A hasher
+  uintDiff ducos1result = ducos1a(lastBlockHash, newBlockHash, difficulty);
+
+  // Calculate elapsed time
+  uint32_t elapsedTime = micros() - startTime;
+
+  // Clearing the receive buffer before sending the result.
+  while (Serial.available()) Serial.read();
+
+  // Send result back to the program with share time
+  Serial.print(String(ducos1result, 2) 
+               + SEP_TOKEN
+               + String(elapsedTime, 2) 
+               + SEP_TOKEN
+               + String(DUCOID) 
+               + END_TOKEN);
+}

--- a/Unofficial miners/W80x_Code/W80x_Code.ino
+++ b/Unofficial miners/W80x_Code/W80x_Code.ino
@@ -59,11 +59,6 @@ void lowercase_hex_to_bytes(char const * hexDigest, uint8_t * rawDigest) {
 
 // DUCO-S1A hasher
 uintDiff ducos1a(char const * prevBlockHash, char const * targetBlockHash, uintDiff difficulty) {
-  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
-    // If the difficulty is too high for AVR architecture then return 0
-    if (difficulty > 655) return 0;
-  #endif
-
   uint8_t target[SHA1_HASH_LEN];
   lowercase_hex_to_bytes(targetBlockHash, target);
 

--- a/Unofficial miners/W80x_Code/duco_hash.cpp
+++ b/Unofficial miners/W80x_Code/duco_hash.cpp
@@ -1,0 +1,1 @@
+../../Arduino_Code/duco_hash.cpp

--- a/Unofficial miners/W80x_Code/duco_hash.h
+++ b/Unofficial miners/W80x_Code/duco_hash.h
@@ -1,0 +1,1 @@
+../../Arduino_Code/duco_hash.h

--- a/Unofficial miners/W80x_Code/w80xID.cpp
+++ b/Unofficial miners/W80x_Code/w80xID.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Duino-Coin Community
+// SPDX-License-Identifier: MIT
+
+#pragma GCC optimize ("-Ofast")
+
+#include "w80xID.h"
+
+W80xUniqueID::W80xUniqueID()
+{
+  id[0] = 0x57; // W
+  id[1] = 0x38; // 8
+  id[2] = 0x30; // 0
+  id[3] = 0x78; // x
+  id[4] = 0x00;
+  id[5] = 0x00;
+  id[6] = 0x00;
+  id[7] = VARIANT;
+}
+
+W80xUniqueID _UniqueID;

--- a/Unofficial miners/W80x_Code/w80xID.h
+++ b/Unofficial miners/W80x_Code/w80xID.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 Duino-Coin Community
+// SPDX-License-Identifier: MIT
+
+#pragma GCC optimize ("-Ofast")
+
+#ifndef _W80x_UNIQUE_ID_H_
+#define _W80x_UNIQUE_ID_H_
+
+#include <stdint.h>
+#include "variant.h"
+
+/* Detect variant of WinnerMicro board */
+#if defined(_VARIANT_ARDUINO_W800_)
+#define VARIANT 0x1
+#elif defined(_VARIANT_ARDUINO_W801_)
+#define VARIANT 0x2
+#elif defined(_VARIANT_ARDUINO_W802_)
+#define VARIANT 0x3
+#elif defined(_VARIANT_ARDUINO_W806_)
+#define VARIANT 0x4
+#elif defined(_VARIANT_ARDUINO_Air101_)
+#define VARIANT 0x10
+#elif defined(_VARIANT_ARDUINO_Air103_)
+#define VARIANT 0x11
+#else
+#error "w80xID requires the board to be WinnerMicro W80x, Air101 or Air103"
+#endif
+
+#define UniqueID8 (_UniqueID.id + UniqueIDbuffer - 8)
+
+/*
+ * Stores variant information of the board
+ *
+ * Use the last byte for variant information:
+ * - 0x0: Unknown
+ * - 0x1: WinnerMicro W800
+ * - 0x2: WinnerMicro W801
+ * - 0x3: WinnerMicro W802
+ * - 0x4: WinnerMicro W806
+ * - 0x10: Air101
+ * - 0x11: Air103
+ *
+ * The String W80x is provided as the first 4 bytes.
+ */
+#define UniqueIDbuffer 8
+
+class W80xUniqueID
+{
+  public:
+	W80xUniqueID();
+	uint8_t id[UniqueIDbuffer];
+};
+
+extern W80xUniqueID _UniqueID;
+
+#endif // _W80x_UNIQUE_ID_H_


### PR DESCRIPTION
This patch introduces support for several boards. They are listed below:
- [Nordic Semiconductor nRF5 based boards](https://github.com/sandeepmistry/arduino-nRF5)
- [WinnerMicro W80x](https://github.com/board707/w80x_arduino)

A separate patch in the AVR miner script is needed to enable support for WinnerMicro W80x.