### PR TITLE
Better Linux checking for Fasthash binaries

### DIFF
--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -19,6 +19,7 @@ from random import randint
 from os import execl, mkdir, _exit
 from os import name as osname
 from os import system as ossystem 
+from os import uname
 from subprocess import DEVNULL, Popen, check_call, PIPE
 import pip
 import sys
@@ -473,7 +474,7 @@ class Donate:
                               'wb') as f:
                         f.write(r.content)
                     return
-            elif os.name == "posix":
+            elif os.name == "posix" and uname().sysname == "Linux":
                 if osprocessor() == "aarch64":
                     url = ('https://server.duinocoin.com/'
                            + 'donations/DonateExecutableAARCH64')

--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -1361,7 +1361,7 @@ class Fasthash:
                 with open(f"libducohasher.pyd", 'wb') as f:
                     f.write(r.content)
                 return
-        elif os.name == "posix":
+        elif os.name == "posix" and uname().sysname == "Linux":
             if osprocessor() == "aarch64":
                 url = ('https://server.duinocoin.com/'
                        + 'fasthash/libducohashPi4.so')


### PR DESCRIPTION
**The issue:**
Currently `os.name` is used to detect Linux to download fasthash binary by comparing the `os.name` to `posix`.
However the `os.name` will result to `posix` on all unix/unix like operating systems like on FreeBSD or OpenBSD

The same goes for the donate binaries

**Fix:**
Using os.uname().system instead or alongside would be a better practice. To compare it to `Linux`.
This is going to add better debugging and better support for unix-like/unix operating systems in future